### PR TITLE
Add auto reconcile only same journal

### DIFF
--- a/account_payment_mode_auto_reconcile/models/account_invoice.py
+++ b/account_payment_mode_auto_reconcile/models/account_invoice.py
@@ -92,7 +92,7 @@ class AccountInvoice(models.Model):
         lines = self.env['account.move.line'].browse(line_ids).filtered(
             lambda line: line.journal_id == self.journal_id
         )
-        return [credit for credit in credits if credit['id'] in lines.ids]
+        return [credit for credit in credits_dict if credit['id'] in lines.ids]
 
     @api.multi
     def auto_unreconcile_credits(self):

--- a/account_payment_mode_auto_reconcile/models/account_invoice.py
+++ b/account_payment_mode_auto_reconcile/models/account_invoice.py
@@ -73,6 +73,8 @@ class AccountInvoice(models.Model):
             # Get outstanding credits in chronological order
             # (using reverse because aml is sorted by date desc as default)
             credits_dict = credits_info.get('content')
+            if invoice.payment_mode_id.auto_reconcile_same_journal:
+                credits_dict = invoice._filter_payment_same_journal(credits_dict)
             credits_dict.reverse()
             for credit in credits_dict:
                 if (
@@ -81,6 +83,16 @@ class AccountInvoice(models.Model):
                 ):
                     continue
                 invoice.assign_outstanding_credit(credit.get('id'))
+
+    @api.multi
+    def _filter_payment_same_journal(self, credits):
+        """Keep only credits on the same journal than the invoice."""
+        self.ensure_one()
+        line_ids = [credit['id'] for credit in credits]
+        lines = self.env['account.move.line'].browse(line_ids).filtered(
+            lambda line: line.journal_id == self.journal_id
+        )
+        return [credit for credit in credits if credit['id'] in lines.ids]
 
     @api.multi
     def auto_unreconcile_credits(self):

--- a/account_payment_mode_auto_reconcile/models/account_invoice.py
+++ b/account_payment_mode_auto_reconcile/models/account_invoice.py
@@ -85,7 +85,7 @@ class AccountInvoice(models.Model):
                 invoice.assign_outstanding_credit(credit.get('id'))
 
     @api.multi
-    def _filter_payment_same_journal(self, credits):
+    def _filter_payment_same_journal(self, credits_dict):
         """Keep only credits on the same journal than the invoice."""
         self.ensure_one()
         line_ids = [credit['id'] for credit in credits_dict]

--- a/account_payment_mode_auto_reconcile/models/account_invoice.py
+++ b/account_payment_mode_auto_reconcile/models/account_invoice.py
@@ -88,7 +88,7 @@ class AccountInvoice(models.Model):
     def _filter_payment_same_journal(self, credits):
         """Keep only credits on the same journal than the invoice."""
         self.ensure_one()
-        line_ids = [credit['id'] for credit in credits]
+        line_ids = [credit['id'] for credit in credits_dict]
         lines = self.env['account.move.line'].browse(line_ids).filtered(
             lambda line: line.journal_id == self.journal_id
         )

--- a/account_payment_mode_auto_reconcile/models/account_payment_mode.py
+++ b/account_payment_mode_auto_reconcile/models/account_payment_mode.py
@@ -9,12 +9,14 @@ class AccountPaymentMode(models.Model):
     _inherit = "account.payment.mode"
 
     auto_reconcile_outstanding_credits = fields.Boolean(
+        string="Auto reconcile",
         help="Reconcile automatically outstanding credits when an invoice "
              "using this payment mode is validated, or when this payment mode "
              "is defined on an open invoice."
     )
     auto_reconcile_allow_partial = fields.Boolean(
         default=True,
+        string="Allow partial",
         help="Allows automatic partial reconciliation of outstanding credits",
     )
     auto_reconcile_same_journal = fields.Boolean(

--- a/account_payment_mode_auto_reconcile/models/account_payment_mode.py
+++ b/account_payment_mode_auto_reconcile/models/account_payment_mode.py
@@ -17,3 +17,8 @@ class AccountPaymentMode(models.Model):
         default=True,
         help="Allows automatic partial reconciliation of outstanding credits",
     )
+    auto_reconcile_same_journal = fields.Boolean(
+        default=False,
+        string="Only same journal",
+        help="Only reconcile payment belonging to the same journal than the invoice",
+    )

--- a/account_payment_mode_auto_reconcile/tests/test_partner_auto_reconcile.py
+++ b/account_payment_mode_auto_reconcile/tests/test_partner_auto_reconcile.py
@@ -213,7 +213,7 @@ class TestPartnerAutoReconcile(SavepointCase):
         auto_rec_invoice.action_invoice_open()
         self.assertEqual(auto_rec_invoice.residual, 500)
 
-    def test_invoice_auto_reconcile_same_journal_not(self):
+    def test_invoice_auto_reconcile_different_journal(self):
         """Check not reconciling credits on different journal."""
         self.payment_mode.auto_reconcile_same_journal = True
         auto_rec_invoice = self.invoice.copy({

--- a/account_payment_mode_auto_reconcile/tests/test_partner_auto_reconcile.py
+++ b/account_payment_mode_auto_reconcile/tests/test_partner_auto_reconcile.py
@@ -55,10 +55,10 @@ class TestPartnerAutoReconcile(SavepointCase):
             })],
         })
         cls.invoice.action_invoice_open()
-        bank_journal = cls.env['account.journal'].search(
+        cls.bank_journal = cls.env['account.journal'].search(
             [('type', '=', 'bank')], limit=1
         )
-        cls.invoice.pay_and_reconcile(bank_journal)
+        cls.invoice.pay_and_reconcile(cls.bank_journal)
         cls.refund_wiz = cls.env['account.invoice.refund'].with_context(
             active_ids=cls.invoice.ids).create({
                 'filter_refund': 'refund',
@@ -192,3 +192,44 @@ class TestPartnerAutoReconcile(SavepointCase):
         new_invoice.write({'payment_mode_id': False})
         self.assertEqual(new_invoice.residual, 1400.0)
         self.assertEqual(other_invoice.state, 'paid')
+
+    def test_invoice_auto_reconcile_same_journal(self):
+        """Check reconciling credits on same journal."""
+        self.payment_mode.auto_reconcile_same_journal = True
+        auto_rec_invoice = self.invoice.copy({
+            'payment_mode_id': self.payment_mode.id,
+        })
+        auto_rec_invoice.write({
+            'invoice_line_ids': [(0, 0, {
+                'product_id': self.product.id,
+                'name': self.product.name,
+                'price_unit': 500.0,
+                'quantity': 1,
+                'account_id': self.acc_rev.id,
+            })]
+        })
+        self.assertTrue(self.payment_mode.auto_reconcile_outstanding_credits)
+        self.assertEqual(self.invoice_copy.residual, 1500)
+        auto_rec_invoice.action_invoice_open()
+        self.assertEqual(auto_rec_invoice.residual, 500)
+
+    def test_invoice_auto_reconcile_same_journal_not(self):
+        """Check not reconciling credits on different journal."""
+        self.payment_mode.auto_reconcile_same_journal = True
+        auto_rec_invoice = self.invoice.copy({
+            'payment_mode_id': self.payment_mode.id,
+            'journal_id': self.bank_journal.id,
+        })
+        auto_rec_invoice.write({
+            'invoice_line_ids': [(0, 0, {
+                'product_id': self.product.id,
+                'name': self.product.name,
+                'price_unit': 500.0,
+                'quantity': 1,
+                'account_id': self.acc_rev.id,
+            })]
+        })
+        self.assertTrue(self.payment_mode.auto_reconcile_outstanding_credits)
+        self.assertEqual(self.invoice_copy.residual, 1500)
+        auto_rec_invoice.action_invoice_open()
+        self.assertEqual(auto_rec_invoice.residual, 1500)

--- a/account_payment_mode_auto_reconcile/views/account_payment_mode.xml
+++ b/account_payment_mode_auto_reconcile/views/account_payment_mode.xml
@@ -9,6 +9,7 @@
                 <group string="Auto reconcile outstanding credits" name="auto_reconcile">
                     <field name="auto_reconcile_outstanding_credits" />
                     <field name="auto_reconcile_allow_partial" attrs="{'invisible': [('auto_reconcile_outstanding_credits', '=', False)]}" />
+                    <field name="auto_reconcile_same_journal" attrs="{'invisible': [('auto_reconcile_outstanding_credits', '=', False)]}" />
                 </group>
             </group>
         </field>


### PR DESCRIPTION
Add an option to auto reconcile only credits that are on the same
journal than the invoice.
This make sure that unrelated payment will not be used automatically.